### PR TITLE
Hotfix/values keyword

### DIFF
--- a/src/components/products/form-variety.svelte
+++ b/src/components/products/form-variety.svelte
@@ -53,7 +53,7 @@
       <RadioGroup
         isColor
         name="choose-color"
-        values={colors.map(val => ({ value: val }))}
+        items={colors.map(val => ({ value: val }))}
         classname="color-choices"
         on:change={(e) => { changeField('color', e.detail); toggle(); }}
       />

--- a/src/components/products/preview-card.svelte
+++ b/src/components/products/preview-card.svelte
@@ -64,7 +64,7 @@
               isColor
               name="variety-colors"
               classname="content"
-              values={colors.map(val => ({ value: val }))}
+              items={colors.map(val => ({ value: val }))}
               value={selectedVariety.color}
               on:change={switchVariety}
             />

--- a/src/components/products/preview-card.svelte
+++ b/src/components/products/preview-card.svelte
@@ -73,7 +73,7 @@
         {#if sizes && product.sized && sizes.length > 1}
           <Labeled label="sizes" classname="mt-2">
             <RadioChipGroup
-              values={sizes}
+              items={sizes}
               small
               name="sizes"
               classname="content"

--- a/src/components/profile/competences-chart.svelte
+++ b/src/components/profile/competences-chart.svelte
@@ -3,9 +3,9 @@
   import colors from '@/constants/profile/competence-colors.js';
 
   export let competences;
-  export let values;
+  export let items;
   $: maxCompetenceValue = Math.max(
-    ...competences.map(comp => values.get(comp.id) || 1),
+    ...competences.map(comp => items.get(comp.id) || 1),
   );
 </script>
 
@@ -14,10 +14,10 @@
     {#each competences as competence, i (competence.id)}
       <div class="bar">
         <div
-          style="flex-basis: {(values.get(competence.id) || 0) / maxCompetenceValue * 90}%;
+          style="flex-basis: {(items.get(competence.id) || 0) / maxCompetenceValue * 90}%;
                  background: rgb({colors[i]});"
           class="future"
-          title="{competence.name}: {values.get(competence.id) || 0}"
+          title="{competence.name}: {items.get(competence.id) || 0}"
         >
           <div style="flex-basis: 100%" class="present" />
         </div>

--- a/src/components/projects/new/edit-activity.svelte
+++ b/src/components/projects/new/edit-activity.svelte
@@ -218,7 +218,7 @@
         <CheckboxGroup
           name="competences"
           maxChecked={3}
-          values={competencesOptions}
+          items={competencesOptions}
           labels={competencesLabels}
           on:change={(e) => {
             modifyCompetences(e);
@@ -362,7 +362,7 @@
       <span class="divider">or</span>
       <CheckboxGroup
         name="the-more"
-        values={[morePeopleCheckbox]}
+        items={[morePeopleCheckbox]}
         labels={["the more, the better"]}
         on:change={(evt) => {
           toggleMorePeople(evt);

--- a/src/components/store/product-card.svelte
+++ b/src/components/store/product-card.svelte
@@ -40,7 +40,7 @@
       />
       <RadioGroup
         isColor
-        values={colors.map(val => ({ value: val }))}
+        items={colors.map(val => ({ value: val }))}
         bind:value={selectedColor}
         classname="color-options"
         name="color-{id}"

--- a/src/components/ui/check-chip-group.svelte
+++ b/src/components/ui/check-chip-group.svelte
@@ -9,19 +9,19 @@
   export let small = false;
   export let outline = false;
 
-  export let values;
+  export let items;
   export let labels = null;
   export let name;
   export let maxChecked = null;
-  $: currentChecked = values.reduce((acc, elt) => acc + elt.checked, 0);
+  $: currentChecked = items.reduce((acc, elt) => acc + elt.checked, 0);
   const titleObj = { title: `Can only select ${itemAmount(maxChecked, 'value')}.` };
 
-  if (values.length === 0) {
+  if (items.length === 0) {
     console.error('Must have at least one value in the checkbox group.');
   }
 
-  if (labels !== null && values.length !== labels.length) {
-    console.error('Must have as many labels as there is values.');
+  if (labels !== null && items.length !== labels.length) {
+    console.error('Must have as many labels as there is items.');
   }
 
   const dispatch = createEventDispatcher();
@@ -36,7 +36,7 @@
 </script>
 
 <div role="group" class:max-reached={currentChecked === maxChecked} class={classname}>
-  {#each values as loopValue, i (i)}
+  {#each items as loopValue, i (i)}
     <label class="chip-wrapper {chipwrapperclass}">
       <input
         bind:checked={loopValue.checked}

--- a/src/components/ui/checkbox-group.svelte
+++ b/src/components/ui/checkbox-group.svelte
@@ -12,20 +12,20 @@
   export let isColor = false;
   export let isRound = false;
 
-  export let values;
+  export let items;
   export let labels = null;
   export let name;
   export let labelPosition = 'right';
   export let maxChecked = null;
-  $: currentChecked = values.reduce((acc, elt) => acc + elt.checked, 0);
+  $: currentChecked = items.reduce((acc, elt) => acc + elt.checked, 0);
   const titleObj = { title: `Can only select ${itemAmount(maxChecked, 'value')}.` };
 
-  if (values.length === 0) {
+  if (items.length === 0) {
     console.error('Must have at least one value in the checkbox group.');
   }
 
-  if (labels !== null && values.length !== labels.length) {
-    console.error('Must have as many labels as there is values.');
+  if (labels !== null && items.length !== labels.length) {
+    console.error('Must have as many labels as there is items.');
   }
 
   if (labelPosition !== 'right' && labelPosition !== 'left') {
@@ -49,7 +49,7 @@
   class={classname}
   role="group"
 >
-  {#each values as loopValue, i (i)}
+  {#each items as loopValue, i (i)}
     <label class:clickable={!isColor} class={wrapperclass}>
       {#if !isColor && labelPosition === 'left'}
         {#if labelclass !== null}

--- a/src/components/ui/radio-chip-group.svelte
+++ b/src/components/ui/radio-chip-group.svelte
@@ -8,17 +8,17 @@
   export let small = false;
   export let outline = false;
 
-  export let values;
+  export let items;
   export let labels = null;
   export let value = null;
   export let name;
 
-  if (values.length === 0) {
+  if (items.length === 0) {
     console.error('Must have at least one value in the checkbox group.');
   }
 
-  if (labels !== null && values.length !== labels.length) {
-    console.error('Must have as many labels as there is values.');
+  if (labels !== null && items.length !== labels.length) {
+    console.error('Must have as many labels as there is items.');
   }
 
   const dispatch = createEventDispatcher();
@@ -28,7 +28,7 @@
 </script>
 
 <div role="group" class={classname}>
-  {#each values as loopValue, i (i)}
+  {#each items as loopValue, i (i)}
     <label class="chip-wrapper {chipwrapperclass}">
       <input
         bind:group={value}

--- a/src/components/ui/radio-group.svelte
+++ b/src/components/ui/radio-group.svelte
@@ -10,18 +10,18 @@
   export let iconclass = '';
   export let isColor = false;
 
-  export let values;
+  export let items;
   export let labels = null;
   export let value = null;
   export let name;
   export let labelPosition = 'right';
 
-  if (values.length === 0) {
+  if (items.length === 0) {
     console.error('Must have at least one item in the radio group.');
   }
 
-  if (labels !== null && values.length !== labels.length) {
-    console.error('Must have as many labels as there is values.');
+  if (labels !== null && items.length !== labels.length) {
+    console.error('Must have as many labels as there is items.');
   }
 
   if (labelPosition !== 'right' && labelPosition !== 'left') {
@@ -35,7 +35,7 @@
 </script>
 
 <div class:with-labels={!isColor} class={classname} role="group">
-  {#each values as loopValue, i (i)}
+  {#each items as loopValue, i (i)}
     <label
       class:colored={isColor}
       class:radio={isColor}

--- a/src/components/ui/tabs.svelte
+++ b/src/components/ui/tabs.svelte
@@ -5,24 +5,24 @@
   export let iconclass = '';
   export let inputclass = '';
 
-  export let values;
+  export let items;
   export let value = null;
   export let labels = null;
   export let name;
 
   const dispatch = createEventDispatcher();
 
-  if (values.length === 0) {
+  if (items.length === 0) {
     console.error('Must have at least one item in the radio group.');
   }
 
-  if (labels !== null && values.length !== labels.length) {
-    console.error('Must have as many labels as there is values.');
+  if (labels !== null && items.length !== labels.length) {
+    console.error('Must have as many labels as there is items.');
   }
 </script>
 
 <nav class="tabs {classname}">
-  {#each values as loopValue, i (i)}
+  {#each items as loopValue, i (i)}
     <label class="tab {tabclass}">
       <input
         type="radio"

--- a/src/containers/products/item-content.svelte
+++ b/src/containers/products/item-content.svelte
@@ -58,7 +58,7 @@
       <Labeled label="colors" classname="colors">
         <RadioGroup
           isColor
-          values={productControl.colors.map(val => ({ value: val }))}
+          items={productControl.colors.map(val => ({ value: val }))}
           classname="radio-options"
           bind:value={selectedColor}
           on:change={({ detail }) => dispatch('color-change', detail)}

--- a/src/containers/products/item-content.svelte
+++ b/src/containers/products/item-content.svelte
@@ -73,7 +73,7 @@
       >
         <RadioChipGroup
           labels={productControl.varietiesByColor.get(selectedColor).map(x => x.size)}
-          values={productControl.varietiesByColor.get(selectedColor).map(x => x.id)}
+          items={productControl.varietiesByColor.get(selectedColor).map(x => x.id)}
           small
           name="sizes"
           classname="radio-options"

--- a/src/containers/profile/notifications.svelte
+++ b/src/containers/profile/notifications.svelte
@@ -98,7 +98,7 @@
           name={category.key || 'all'}
           labelPosition="left"
           labelclass="label"
-          values={radioOptions}
+          items={radioOptions}
           value={notificationSettings[category.key]}
           on:change={(evt) => updateSettings(category.key, evt.detail)}
         />

--- a/src/containers/profile/statistics.svelte
+++ b/src/containers/profile/statistics.svelte
@@ -56,6 +56,6 @@
       <svg src="images/icons/bar-chart-2.svg" class="icon" />
       Developed competences
     </header>
-    <CompetencesChart {competences} values={indexify(statistics.competences)} />
+    <CompetencesChart {competences} items={indexify(statistics.competences)} />
   </div>
 </section>

--- a/src/containers/projects/filters.svelte
+++ b/src/containers/projects/filters.svelte
@@ -126,7 +126,7 @@
       <span slot="label" class="tight">order</span>
       <span slot="label" class="regular">{orderLabel}</span>
       <RadioGroup
-        values={orderOptions.map(val => ({ value: val }))}
+        items={orderOptions.map(val => ({ value: val }))}
         labels={orderLabels}
         name="order-options-mobile"
         bind:value={order}
@@ -198,7 +198,6 @@
         </AccordionSection>
       </Accordion>
     </Dropdown>
-
   </div>
 </div>
 <RadioChipGroup

--- a/src/containers/projects/filters.svelte
+++ b/src/containers/projects/filters.svelte
@@ -174,7 +174,7 @@
           <Button on:click={clearCompetenceExclusion}>select all</Button>
           <CheckboxGroup
             labels={competences.map(compObject => compObject.name.toLowerCase())}
-            values={competences}
+            items={competences}
             name="competences"
             on:change={(e) => changeCompetences(e.detail)}
           />

--- a/src/containers/projects/filters.svelte
+++ b/src/containers/projects/filters.svelte
@@ -202,7 +202,7 @@
   </div>
 </div>
 <RadioChipGroup
-  values={orderOptions}
+  items={orderOptions}
   labels={orderLabels}
   name="order-options"
   bind:value={order}

--- a/src/containers/projects/new/step-3.svelte
+++ b/src/containers/projects/new/step-3.svelte
@@ -88,7 +88,7 @@
     You are the creator, therefore, also a moderator.
   </p>
   <span class="label">Search for people</span>
-  <Autocomplete getOptions={getUsers} on:change={recordChanges} />
+  <Autocomplete selection={values} getOptions={getUsers} on:change={recordChanges} />
   <BottomNavigation
     step={3}
     error={

--- a/src/containers/projects/new/step-3.svelte
+++ b/src/containers/projects/new/step-3.svelte
@@ -88,7 +88,7 @@
     You are the creator, therefore, also a moderator.
   </p>
   <span class="label">Search for people</span>
-  <Autocomplete values={values} getOptions={getUsers} on:change={recordChanges} />
+  <Autocomplete getOptions={getUsers} on:change={recordChanges} />
   <BottomNavigation
     step={3}
     error={

--- a/src/containers/store/filters.svelte
+++ b/src/containers/store/filters.svelte
@@ -157,13 +157,13 @@
               isColor
               isRound
               name="colors"
-              values={colors}
+              items={colors}
               classname="color-grid"
               on:change={(e) => changeColors(e.detail)}
             />
             <CheckboxGroup
               name="colorless"
-              values={colorlessValues}
+              items={colorlessValues}
               labels={['colorless']}
               on:change={(e) => changeColorless(e.detail)}
             />

--- a/src/containers/store/filters.svelte
+++ b/src/containers/store/filters.svelte
@@ -106,7 +106,7 @@
       <span slot="label" class="tight">order</span>
       <span slot="label" class="regular">{orderLabel}</span>
       <RadioGroup
-        values={orderOptions.map(val => ({ value: val }))}
+        items={orderOptions.map(val => ({ value: val }))}
         labels={orderLabels}
         name="order-options-mobile"
         bind:value={order}

--- a/src/containers/store/filters.svelte
+++ b/src/containers/store/filters.svelte
@@ -174,7 +174,7 @@
   </div>
 </div>
 <RadioChipGroup
-  values={orderOptions}
+  items={orderOptions}
   labels={orderLabels}
   name="order-options"
   bind:value={order}

--- a/src/containers/ui/checkboxes.svelte
+++ b/src/containers/ui/checkboxes.svelte
@@ -20,13 +20,13 @@
   <div class="showcase">
     <CheckboxGroup
         name="checkboxes0"
-        bind:values={values}
+        bind:items={values}
         labels={labels}
     />
     <hr />
     <CheckboxGroup
         name="checkboxes1"
-        bind:values={values}
+        bind:items={values}
         labelclass="label"
         labelPosition="left"
         classname="flex-wrap"
@@ -37,7 +37,7 @@
         name="checkboxes2"
         isColor
         isRound
-        bind:values={colors}
+        bind:items={colors}
         classname="flex-wrap"
     />
   </div>

--- a/src/containers/ui/chips.svelte
+++ b/src/containers/ui/chips.svelte
@@ -29,9 +29,9 @@
     {/each}
   </div>
   <hr />
-  <CheckChipGroup bind:values={checkValues} labels={labels} name="chip0" classname="flex-wrap" />
+  <CheckChipGroup bind:items={checkValues} labels={labels} name="chip0" classname="flex-wrap" />
   <hr />
-  <CheckChipGroup outline bind:values={checkValues} name="chip1" classname="flex-wrap" maxChecked={1} />
+  <CheckChipGroup outline bind:items={checkValues} name="chip1" classname="flex-wrap" maxChecked={1} />
   <hr />
   <RadioChipGroup bind:value={selectedValue} items={radioValues} labels={labels} name="chip2" classname="flex-wrap" />
   <hr />

--- a/src/containers/ui/chips.svelte
+++ b/src/containers/ui/chips.svelte
@@ -33,7 +33,7 @@
   <hr />
   <CheckChipGroup outline bind:values={checkValues} name="chip1" classname="flex-wrap" maxChecked={1} />
   <hr />
-  <RadioChipGroup bind:value={selectedValue} values={radioValues} labels={labels} name="chip2" classname="flex-wrap" />
+  <RadioChipGroup bind:value={selectedValue} items={radioValues} labels={labels} name="chip2" classname="flex-wrap" />
   <hr />
-  <RadioChipGroup small bind:value={selectedValue} values={radioValues} name="chip3" classname="flex-wrap" />
+  <RadioChipGroup small bind:value={selectedValue} items={radioValues} name="chip3" classname="flex-wrap" />
 </Card>

--- a/src/containers/ui/radios.svelte
+++ b/src/containers/ui/radios.svelte
@@ -13,14 +13,14 @@
   <div class="showcase">
     <RadioGroup
         name="radio0"
-        values={values.map(val => ({ value: val }))}
+        items={values.map(val => ({ value: val }))}
         labels={labels}
         bind:value={currValue}
     />
     <hr />
     <RadioGroup
         name="radio1"
-        values={values.map(val => ({ value: val }))}
+        items={values.map(val => ({ value: val }))}
         labelclass="label"
         labelPosition="left"
         bind:value={currValue}
@@ -30,7 +30,7 @@
     <RadioGroup
         isColor
         name="radio2"
-        values={colors.map(val => ({ value: val }))}
+        items={colors.map(val => ({ value: val }))}
         classname="flex-wrap"
     />
   </div>

--- a/src/routes/profile.svelte
+++ b/src/routes/profile.svelte
@@ -151,7 +151,7 @@
     <Info {account} on:username-change={changeUsername} />
     <section class="card">
       <Tabs
-        values={Object.keys(tabs)}
+        items={Object.keys(tabs)}
         labels={Object.keys(tabs).map(capitalize)}
         value={activeTab}
         name="nav-tabs"


### PR DESCRIPTION
For some weird reason (that took hours to find out its cause), using the prop name `values` causes the following error:
![image](https://user-images.githubusercontent.com/11016151/77004192-c247e780-696f-11ea-8f73-e5baeb51fa62.png)
It has been observed only when running in Docker in development mode, but it is still worth fixing. The root cause of this problem is unknown (couldn't find anything on the internet), but this workaround fixes it anyway.
All `values` props have been renamed to `items`.